### PR TITLE
Allow multiple interfaces to be configured for each network namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install:
 	install --owner=root --group=root --mode=644 configs/netns $(DESTDIR)/etc/default/
 	install --owner=root --group=root --mode=755 scripts/chnetns $(DESTDIR)/usr/bin/
 	install --owner=root --group=root --mode=755 scripts/netnsinit $(DESTDIR)/usr/sbin/
+	install --owner=root --group=root --mode=755 scripts/netnsctl $(DESTDIR)/usr/sbin/
 	systemctl daemon-reload || true
 
 uninstall:
@@ -28,3 +29,4 @@ uninstall:
 	rm -f $(DESTDIR)/$(LIBDIR)/systemd/system/netns-veth@.service
 	rm -f $(DESTDIR)/usr/bin/chnetns
 	rm -f $(DESTDIR)/usr/sbin/netnsinit
+	rm -f $(DESTDIR)/usr/sbin/netnsctl

--- a/debian/netnsinit.8
+++ b/debian/netnsinit.8
@@ -2,7 +2,7 @@
 .SH NAME
 \fInetnsinit\fR \- configure named network namespace
 .SH SYNOPSIS
-netnsinit <network\-type> <ns\-name>
+netnsinit <network\-type> <ns\-name> <config\-file>
 .SH DESCRIPTION
 Auto configuration for \fBsystemd\-named\-netns\fR. Not intended for manual invocation.
 .PP

--- a/scripts/netnsctl
+++ b/scripts/netnsctl
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -e
+
+display_usage() {
+    echo "Start/stop systemd-named-netns interfaces."
+    echo -e "\nUsage:\n\t$0 [start|stop] ns-name ns-type\n"
+    echo "Note: you may need root privileges for this."
+}
+
+start_raw() {
+    for config in /etc/default/netns-${NSNAME}/raw.*; do
+        [ -e ${config} ] || continue
+        # use a subshell so each interface is configured in a fresh environment
+        (
+            . ${config}
+            /usr/bin/env tc qdisc del dev ${DEVNAME} root || true
+            /usr/bin/env ip link set ${DEVNAME} netns ${NSNAME}
+            /usr/bin/env ip netns exec ${NSNAME} /usr/bin/env ip link set ${DEVNAME} up
+            /usr/bin/env ip netns exec ${NSNAME} /usr/bin/env netnsinit interface ${NSNAME} ${DEVNAME} ${config}
+        )
+    done
+}
+
+stop_raw() {
+    for config in /etc/default/netns-${NSNAME}/raw.*; do
+        [ -e ${config} ] || continue
+        # use a subshell so each interface is configured in a fresh environment
+        (
+            . ${config}
+            /usr/bin/env kill -15 `cat /var/run/dhclient-${NSNAME}_${DEVNAME}.pid` || true
+            /usr/bin/env rm /var/run/dhclient-${NSNAME}_${DEVNAME}.pid || true
+            /usr/bin/env ip netns exec ${NSNAME} ip link set ${DEVNAME} netns 1
+        )
+    done
+}
+
+start_veth() {
+    # Bridge depends on veth and needs interfaces to be configured too.
+    # If there are multiple bridges and/or veths in one namespace then
+    # device names will need to be set manually otherwise they will all
+    # use the same default values, causing clashes and failure.
+    for config in /etc/default/netns-${NSNAME}/veth.* /etc/default/netns-${NSNAME}/bridge.*; do
+        [ -e ${config} ] || continue
+        # use a subshell so each interface is configured in a fresh environment
+        (
+            . ${config}
+            /usr/bin/env ip link delete ${DEVNAME_OUTSIDE} || true
+            /usr/bin/env ip link delete ${DEVNAME_INSIDE} || true
+            /usr/bin/env ip link add ${DEVNAME_OUTSIDE} type veth peer name ${DEVNAME_INSIDE}
+            /usr/bin/env tc qdisc del dev ${DEVNAME_INSIDE} root || true
+            /usr/bin/env ip link set ${DEVNAME_OUTSIDE} up
+            /usr/bin/env ip link set ${DEVNAME_INSIDE} netns ${NSNAME}
+            /usr/bin/env ip address add ${IPADDR_OUTSIDE} dev ${DEVNAME_OUTSIDE} || true
+            /usr/bin/env ip netns exec ${NSNAME} /usr/bin/env ip link set ${DEVNAME_INSIDE} up
+            /usr/bin/env ip netns exec ${NSNAME} /usr/bin/env netnsinit interface ${NSNAME} ${DEVNAME_INSIDE} ${config}
+        )
+    done
+}
+
+stop_veth() {
+    for config in /etc/default/netns-${NSNAME}/veth.* /etc/default/netns-${NSNAME}/bridge.*; do
+        [ -e ${config} ] || continue
+        (
+            . ${config}
+            /usr/bin/env kill -15 `cat /var/run/dhclient-${NSNAME}_${DEVNAME_INSIDE}.pid` || true
+            /usr/bin/env rm /var/run/dhclient-${NSNAME}_${DEVNAME_INSIDE}.pid || true
+            /usr/bin/env ip link delete ${DEVNAME_OUTSIDE}
+        )
+    done
+}
+
+start_bridge() {
+    for config in /etc/default/netns-${NSNAME}/bridge.*; do
+        [ -e ${config} ] || continue
+        (
+            . ${config}
+            /usr/bin/env ip link set ${DEVNAME_OUTSIDE} master ${BRIDGE}
+            /usr/bin/env ip netns exec ${NSNAME} /usr/bin/env netnsinit bridge ${NSNAME} ${DEVNAME_INSIDE} ${config}
+        )
+    done
+}
+
+start_stop_namespace() {
+    local ACTION=$1
+    local NSNAME=$2
+    local NSTYPE=$3
+
+    # not every type of interface in a namespace has every action
+    if type -t ${ACTION}_${NSTYPE} >/dev/null ; then
+        ${ACTION}_${NSTYPE} "${NSNAME}"
+    fi
+}
+
+
+if [ $# != 3 ]; then
+	display_usage
+	exit 1
+fi
+
+case "$1" in
+    "--help" | "-h")
+        display_usage
+        exit 0
+        ;;
+    "start"|"stop")
+        start_stop_namespace "$@"
+        exit 0
+        ;;
+    *)
+        display_usage
+        exit 1
+        ;;
+esac

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -13,8 +13,7 @@ autoconfigure_interface() {
 		/bin/ip link set ${DEVNAME_INSIDE} address ${MACADDR}
 	fi
 	if [ "${DHCPV4}" == "1" ]; then
-		! mkdir -p /var/run/netns
-		dhclient -v -i ${DEVNAME_INSIDE} -nw -pf /var/run/netns/dhclient-${NSNAME}.pid
+		dhclient -v -i ${DEVNAME_INSIDE} -nw -pf /var/run/dhclient-${NSNAME}.pid
 	else
 		if [ ! -z "${IPADDR_V4}" ]; then
 			/bin/ip address add ${IPADDR_V4} dev ${DEVNAME_INSIDE}

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -4,7 +4,7 @@ set -e
 
 display_usage() {
 	echo "Auto configuration for systemd-named-netns."
-	echo -e "\nUsage:\n\t$0 network-type ns-name \n"
+	echo -e "\nUsage:\n\t$0 network-type ns-name config-file\n"
 	echo "Note: you may need root privileges for this."
 }
 
@@ -13,7 +13,7 @@ autoconfigure_interface() {
 		/bin/ip link set ${DEVNAME_INSIDE} address ${MACADDR}
 	fi
 	if [ "${DHCPV4}" == "1" ]; then
-		dhclient -v -i ${DEVNAME_INSIDE} -nw -pf /var/run/dhclient-${NSNAME}.pid
+		dhclient -v -i ${DEVNAME_INSIDE} -nw -pf /var/run/dhclient-${NSNAME}_${DEVNAME_INSIDE}.pid
 	else
 		if [ ! -z "${IPADDR_V4}" ]; then
 			/bin/ip address add ${IPADDR_V4} dev ${DEVNAME_INSIDE}
@@ -34,11 +34,12 @@ autoconfigure_interface() {
 autoconfigure() {
 	local NSTYPE=$1
 	local NSNAME=$2
+	local DEVNAME_INSIDE=$3
+	local CONFIG=$4
 
 	echo "Starting autoconfigure for $NSTYPE ${NSNAME}"
-	DEVNAME_INSIDE=$3
-	source /etc/default/netns
-	! source "/etc/default/netns-${NSNAME}"
+
+	source "${CONFIG}"
 
 	if type -t autoconfigure_$NSTYPE >/dev/null ; then
 		autoconfigure_$NSTYPE "$@"

--- a/services/netns-bridge@.service
+++ b/services/netns-bridge@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Bridging service for netns %I
+Description=Bridging service for netns %i
 Documentation=https://github.com/Jamesits/systemd-named-netns
 
 BindsTo=netns-veth@%i.service
@@ -13,11 +13,11 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Environment=DEVNAME_OUTSIDE=veth-%I
+Environment=DEVNAME_OUTSIDE=veth-%i
 Environment=DEVNAME_INSIDE=veth0
 EnvironmentFile=/etc/default/netns
-EnvironmentFile=-/etc/default/netns-%I
+EnvironmentFile=-/etc/default/netns-%i
 
 ExecStart=/usr/bin/env ip link set ${DEVNAME_OUTSIDE} master ${BRIDGE}
 
-ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env netnsinit bridge %I ${DEVNAME_INSIDE}
+ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit bridge %i ${DEVNAME_INSIDE}

--- a/services/netns-bridge@.service
+++ b/services/netns-bridge@.service
@@ -15,9 +15,13 @@ Type=oneshot
 RemainAfterExit=yes
 Environment=DEVNAME_OUTSIDE=veth-%i
 Environment=DEVNAME_INSIDE=veth0
-EnvironmentFile=/etc/default/netns
-EnvironmentFile=-/etc/default/netns-%i
 
-ExecStart=/usr/bin/env ip link set ${DEVNAME_OUTSIDE} master ${BRIDGE}
-
-ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit bridge %i ${DEVNAME_INSIDE}
+ExecStart=/bin/sh -c \
+    "set -e; for config in /etc/default/netns-%i/veth.* /etc/default/netns-%i/bridge.*; do \
+        [ -e $${config} ] || continue; \
+        ( \
+        . $${config}; \
+        /usr/bin/env ip link set $${DEVNAME_OUTSIDE} master $${BRIDGE}; \
+        /usr/bin/env ip netns exec %i /usr/bin/env netnsinit bridge %i $${DEVNAME_INSIDE} $${config}; \
+        ); \
+    done"

--- a/services/netns-bridge@.service
+++ b/services/netns-bridge@.service
@@ -16,12 +16,4 @@ RemainAfterExit=yes
 Environment=DEVNAME_OUTSIDE=veth-%i
 Environment=DEVNAME_INSIDE=veth0
 
-ExecStart=/bin/sh -c \
-    "set -e; for config in /etc/default/netns-%i/veth.* /etc/default/netns-%i/bridge.*; do \
-        [ -e $${config} ] || continue; \
-        ( \
-        . $${config}; \
-        /usr/bin/env ip link set $${DEVNAME_OUTSIDE} master $${BRIDGE}; \
-        /usr/bin/env ip netns exec %i /usr/bin/env netnsinit bridge %i $${DEVNAME_INSIDE} $${config}; \
-        ); \
-    done"
+ExecStart=/usr/bin/env netnsctl start %i bridge

--- a/services/netns-raw@.service
+++ b/services/netns-raw@.service
@@ -26,3 +26,4 @@ ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DE
 
 ExecStop=-/usr/bin/env kill -15 `cat /var/run/dhclient-%i.pid`
 ExecStop=-/usr/bin/env rm /var/run/dhclient-%i.pid
+ExecStop=/usr/bin/env ip netns exec %i ip link set ${DEVNAME} netns 1;

--- a/services/netns-raw@.service
+++ b/services/netns-raw@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Raw ethernet service for netns %I
+Description=Raw ethernet service for netns %i
 Documentation=https://github.com/Jamesits/systemd-named-netns
 
 BindsTo=netns@%i.service
@@ -14,15 +14,15 @@ WantedBy=multi-user.target
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/etc/default/netns
-EnvironmentFile=-/etc/default/netns-%I
+EnvironmentFile=-/etc/default/netns-%i
 
 ExecStart=-/usr/bin/env tc qdisc del dev ${DEVNAME} root
-ExecStart=/usr/bin/env ip link set ${DEVNAME} netns %I
+ExecStart=/usr/bin/env ip link set ${DEVNAME} netns %i
 # let this fail silently if IPADDR_OUTSIDE is undefined
-ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env ip link set ${DEVNAME} up
+ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env ip link set ${DEVNAME} up
 
 # do not run in ExecStartPost to prevent forked dhclient from being killed
-ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env netnsinit interface %I ${DEVNAME}
+ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DEVNAME}
 
 ExecStop=-/usr/bin/env kill -15 `cat /var/run/netns/dhclient-%i.pid`
 ExecStop=-/usr/bin/env rm /var/run/netns/dhclient-%i.pid

--- a/services/netns-raw@.service
+++ b/services/netns-raw@.service
@@ -24,5 +24,5 @@ ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env ip link set ${DEVNAME} up
 # do not run in ExecStartPost to prevent forked dhclient from being killed
 ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DEVNAME}
 
-ExecStop=-/usr/bin/env kill -15 `cat /var/run/netns/dhclient-%i.pid`
-ExecStop=-/usr/bin/env rm /var/run/netns/dhclient-%i.pid
+ExecStop=-/usr/bin/env kill -15 `cat /var/run/dhclient-%i.pid`
+ExecStop=-/usr/bin/env rm /var/run/dhclient-%i.pid

--- a/services/netns-raw@.service
+++ b/services/netns-raw@.service
@@ -14,25 +14,5 @@ WantedBy=multi-user.target
 Type=oneshot
 RemainAfterExit=yes
 
-ExecStart=/bin/sh -c \
-    "set -e; for config in /etc/default/netns-%i/raw.*; do \
-        [ -e $${config} ] || continue; \
-        ( \
-        . $${config}; \
-        /usr/bin/env tc qdisc del dev $${DEVNAME} root || true; \
-        /usr/bin/env ip link set $${DEVNAME} netns %i; \
-        /usr/bin/env ip netns exec %i /usr/bin/env ip link set $${DEVNAME} up; \
-        /usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i $${DEVNAME} $${config}; \
-        ); \
-    done"
-
-ExecStop=/bin/sh -c \
-    "set -e; for config in /etc/default/netns-%i/raw.*; do \
-        [ -e $${config} ] || continue; \
-        ( \
-        . $${config}; \
-        /usr/bin/env kill -15 `cat /var/run/dhclient-%i_$${DEVNAME}.pid` || true; \
-        /usr/bin/env rm /var/run/dhclient-%i_$${DEVNAME}.pid || true; \
-        /usr/bin/env ip netns exec %i ip link set $${DEVNAME} netns 1; \
-        ); \
-    done"
+ExecStart=/usr/bin/env netnsctl start %i raw
+ExecStop=/usr/bin/env netnsctl stop %i raw

--- a/services/netns-raw@.service
+++ b/services/netns-raw@.service
@@ -13,17 +13,26 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-EnvironmentFile=/etc/default/netns
-EnvironmentFile=-/etc/default/netns-%i
 
-ExecStart=-/usr/bin/env tc qdisc del dev ${DEVNAME} root
-ExecStart=/usr/bin/env ip link set ${DEVNAME} netns %i
-# let this fail silently if IPADDR_OUTSIDE is undefined
-ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env ip link set ${DEVNAME} up
+ExecStart=/bin/sh -c \
+    "set -e; for config in /etc/default/netns-%i/raw.*; do \
+        [ -e $${config} ] || continue; \
+        ( \
+        . $${config}; \
+        /usr/bin/env tc qdisc del dev $${DEVNAME} root || true; \
+        /usr/bin/env ip link set $${DEVNAME} netns %i; \
+        /usr/bin/env ip netns exec %i /usr/bin/env ip link set $${DEVNAME} up; \
+        /usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i $${DEVNAME} $${config}; \
+        ); \
+    done"
 
-# do not run in ExecStartPost to prevent forked dhclient from being killed
-ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DEVNAME}
-
-ExecStop=-/usr/bin/env kill -15 `cat /var/run/dhclient-%i.pid`
-ExecStop=-/usr/bin/env rm /var/run/dhclient-%i.pid
-ExecStop=/usr/bin/env ip netns exec %i ip link set ${DEVNAME} netns 1;
+ExecStop=/bin/sh -c \
+    "set -e; for config in /etc/default/netns-%i/raw.*; do \
+        [ -e $${config} ] || continue; \
+        ( \
+        . $${config}; \
+        /usr/bin/env kill -15 `cat /var/run/dhclient-%i_$${DEVNAME}.pid` || true; \
+        /usr/bin/env rm /var/run/dhclient-%i_$${DEVNAME}.pid || true; \
+        /usr/bin/env ip netns exec %i ip link set $${DEVNAME} netns 1; \
+        ); \
+    done"

--- a/services/netns-veth@.service
+++ b/services/netns-veth@.service
@@ -32,6 +32,6 @@ ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env ip link set ${DEVNAME_INSID
 # do not run in ExecStartPost to prevent forked dhclient from being killed
 ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DEVNAME_INSIDE}
 
-ExecStop=-/usr/bin/env kill -15 `cat /var/run/netns/dhclient-%i.pid`
-ExecStop=-/usr/bin/env rm /var/run/netns/dhclient-%i.pid
+ExecStop=-/usr/bin/env kill -15 `cat /var/run/dhclient-%i.pid`
+ExecStop=-/usr/bin/env rm /var/run/dhclient-%i.pid
 ExecStop=/usr/bin/env ip link delete ${DEVNAME_OUTSIDE}

--- a/services/netns-veth@.service
+++ b/services/netns-veth@.service
@@ -16,30 +16,5 @@ RemainAfterExit=yes
 Environment=DEVNAME_OUTSIDE=veth-%i
 Environment=DEVNAME_INSIDE=veth0
 
-ExecStart=/bin/sh -c \
-    "set -e; for config in /etc/default/netns-%i/veth.* /etc/default/netns-%i/bridge.*; do \
-        [ -e $${config} ] || continue; \
-        ( \
-        . $${config}; \
-        /usr/bin/env ip link delete $${DEVNAME_OUTSIDE} || true; \
-        /usr/bin/env ip link delete $${DEVNAME_INSIDE} || true; \
-        /usr/bin/env ip link add $${DEVNAME_OUTSIDE} type veth peer name $${DEVNAME_INSIDE}; \
-        /usr/bin/env tc qdisc del dev $${DEVNAME_INSIDE} root || true; \
-        /usr/bin/env ip link set $${DEVNAME_OUTSIDE} up; \
-        /usr/bin/env ip link set $${DEVNAME_INSIDE} netns %i; \
-        /usr/bin/env ip address add $${IPADDR_OUTSIDE} dev $${DEVNAME_OUTSIDE} || true; \
-        /usr/bin/env ip netns exec %i /usr/bin/env ip link set $${DEVNAME_INSIDE} up; \
-        /usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i $${DEVNAME_INSIDE} $${config}; \
-        ); \
-    done"
-
-ExecStop=/bin/sh -c \
-    "set -e; for config in /etc/default/netns-%i/veth.* /etc/default/netns-%i/bridge.*; do \
-        [ -e $${config} ] || continue; \
-        ( \
-        . $${config}; \
-        /usr/bin/env kill -15 `cat /var/run/dhclient-%i_$${DEVNAME_INSIDE}.pid` || true; \
-        /usr/bin/env rm /var/run/dhclient-%i_$${DEVNAME_INSIDE}.pid || true; \
-        /usr/bin/env ip link delete $${DEVNAME_OUTSIDE}; \
-        ); \
-    done"
+ExecStart=/usr/bin/env netnsctl start %i veth
+ExecStop=/usr/bin/env netnsctl stop %i veth

--- a/services/netns-veth@.service
+++ b/services/netns-veth@.service
@@ -15,23 +15,31 @@ Type=oneshot
 RemainAfterExit=yes
 Environment=DEVNAME_OUTSIDE=veth-%i
 Environment=DEVNAME_INSIDE=veth0
-EnvironmentFile=/etc/default/netns
-EnvironmentFile=-/etc/default/netns-%i
 
-ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_OUTSIDE}
-ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}
+ExecStart=/bin/sh -c \
+    "set -e; for config in /etc/default/netns-%i/veth.* /etc/default/netns-%i/bridge.*; do \
+        [ -e $${config} ] || continue; \
+        ( \
+        . $${config}; \
+        /usr/bin/env ip link delete $${DEVNAME_OUTSIDE} || true; \
+        /usr/bin/env ip link delete $${DEVNAME_INSIDE} || true; \
+        /usr/bin/env ip link add $${DEVNAME_OUTSIDE} type veth peer name $${DEVNAME_INSIDE}; \
+        /usr/bin/env tc qdisc del dev $${DEVNAME_INSIDE} root || true; \
+        /usr/bin/env ip link set $${DEVNAME_OUTSIDE} up; \
+        /usr/bin/env ip link set $${DEVNAME_INSIDE} netns %i; \
+        /usr/bin/env ip address add $${IPADDR_OUTSIDE} dev $${DEVNAME_OUTSIDE} || true; \
+        /usr/bin/env ip netns exec %i /usr/bin/env ip link set $${DEVNAME_INSIDE} up; \
+        /usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i $${DEVNAME_INSIDE} $${config}; \
+        ); \
+    done"
 
-ExecStart=/usr/bin/env ip link add ${DEVNAME_OUTSIDE} type veth peer name ${DEVNAME_INSIDE}
-ExecStart=-/usr/bin/env tc qdisc del dev ${DEVNAME_INSIDE} root
-ExecStart=/usr/bin/env ip link set ${DEVNAME_OUTSIDE} up
-ExecStart=/usr/bin/env ip link set ${DEVNAME_INSIDE} netns %i
-# let this fail silently if IPADDR_OUTSIDE is undefined
-ExecStart=-/usr/bin/env ip address add ${IPADDR_OUTSIDE} dev ${DEVNAME_OUTSIDE}
-ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env ip link set ${DEVNAME_INSIDE} up
-
-# do not run in ExecStartPost to prevent forked dhclient from being killed
-ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DEVNAME_INSIDE}
-
-ExecStop=-/usr/bin/env kill -15 `cat /var/run/dhclient-%i.pid`
-ExecStop=-/usr/bin/env rm /var/run/dhclient-%i.pid
-ExecStop=/usr/bin/env ip link delete ${DEVNAME_OUTSIDE}
+ExecStop=/bin/sh -c \
+    "set -e; for config in /etc/default/netns-%i/veth.* /etc/default/netns-%i/bridge.*; do \
+        [ -e $${config} ] || continue; \
+        ( \
+        . $${config}; \
+        /usr/bin/env kill -15 `cat /var/run/dhclient-%i_$${DEVNAME_INSIDE}.pid` || true; \
+        /usr/bin/env rm /var/run/dhclient-%i_$${DEVNAME_INSIDE}.pid || true; \
+        /usr/bin/env ip link delete $${DEVNAME_OUTSIDE}; \
+        ); \
+    done"

--- a/services/netns-veth@.service
+++ b/services/netns-veth@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Tunnel service for netns %I
+Description=Tunnel service for netns %i
 Documentation=https://github.com/Jamesits/systemd-named-netns
 
 BindsTo=netns@%i.service
@@ -13,10 +13,10 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Environment=DEVNAME_OUTSIDE=veth-%I
+Environment=DEVNAME_OUTSIDE=veth-%i
 Environment=DEVNAME_INSIDE=veth0
 EnvironmentFile=/etc/default/netns
-EnvironmentFile=-/etc/default/netns-%I
+EnvironmentFile=-/etc/default/netns-%i
 
 ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_OUTSIDE}
 ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}
@@ -24,13 +24,13 @@ ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}
 ExecStart=/usr/bin/env ip link add ${DEVNAME_OUTSIDE} type veth peer name ${DEVNAME_INSIDE}
 ExecStart=-/usr/bin/env tc qdisc del dev ${DEVNAME_INSIDE} root
 ExecStart=/usr/bin/env ip link set ${DEVNAME_OUTSIDE} up
-ExecStart=/usr/bin/env ip link set ${DEVNAME_INSIDE} netns %I
+ExecStart=/usr/bin/env ip link set ${DEVNAME_INSIDE} netns %i
 # let this fail silently if IPADDR_OUTSIDE is undefined
 ExecStart=-/usr/bin/env ip address add ${IPADDR_OUTSIDE} dev ${DEVNAME_OUTSIDE}
-ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env ip link set ${DEVNAME_INSIDE} up
+ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env ip link set ${DEVNAME_INSIDE} up
 
 # do not run in ExecStartPost to prevent forked dhclient from being killed
-ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env netnsinit interface %I ${DEVNAME_INSIDE}
+ExecStart=/usr/bin/env ip netns exec %i /usr/bin/env netnsinit interface %i ${DEVNAME_INSIDE}
 
 ExecStop=-/usr/bin/env kill -15 `cat /var/run/netns/dhclient-%i.pid`
 ExecStop=-/usr/bin/env rm /var/run/netns/dhclient-%i.pid

--- a/services/netns@.service
+++ b/services/netns@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Named network namespace %I
+Description=Named network namespace %i
 Documentation=https://github.com/Jamesits/systemd-named-netns
 
 After=network-pre.target
@@ -14,10 +14,10 @@ Type=oneshot
 RemainAfterExit=yes
 PrivateNetwork=yes
 
-ExecStartPre=-/usr/bin/env ip netns delete %I
+ExecStartPre=-/usr/bin/env ip netns delete %i
 
-ExecStart=/usr/bin/env ip netns add %I
-ExecStart=/usr/bin/env umount /var/run/netns/%I
-ExecStart=/usr/bin/env mount --bind /proc/self/ns/net /var/run/netns/%I
+ExecStart=/usr/bin/env ip netns add %i
+ExecStart=/usr/bin/env umount /var/run/netns/%i
+ExecStart=/usr/bin/env mount --bind /proc/self/ns/net /var/run/netns/%i
 
-ExecStop=/usr/bin/env ip netns delete %I
+ExecStop=/usr/bin/env ip netns delete %i


### PR DESCRIPTION
Move from a configuration file to a configuration directory for each network namespace, with one file per interface, allowing multiple bridge/veth/raw configs to coexist in the same namespace.